### PR TITLE
Fix mcrypt_get_cipher_name().

### DIFF
--- a/src/mcrypt.php
+++ b/src/mcrypt.php
@@ -618,11 +618,13 @@ function mcrypt_get_cipher_name($cipher)
         'skipjack' => false,
     );
 
-    if (!in_array($cipher, array_values($names))) {
-        return false;
+    if (isset($names[$cypher]) && $names[$cypher]) {
+        return $names[$cypher];
     }
 
-    return $names[$cipher];
+    trigger_error('mcrypt_get_cipher_name(): Module initialization failed', E_USER_WARNING);
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
Not sure what was happening before, but this makes sense.

Note: I'm triggering a warning in the same way the native function would. I would guess that's a policy of this project, when possible.
