### PR TITLE
Simple implementation of 3DES.

### DIFF
--- a/src/mcrypt.php
+++ b/src/mcrypt.php
@@ -981,10 +981,12 @@ function mcrypt_encrypt($cipher, $key, $data, $mode, $iv = null)
     list($prefix) = explode('-', $cipher);
 
     switch ($prefix) {
-
         case 'tripledes':
             $crypt = new TripleDES($mode);
             break;
+
+        default:
+            throw new \cweagans\mcrypt\Exception\NotImplementedException();
     }
 
     $crypt->setKey($key);
@@ -1021,10 +1023,12 @@ function mcrypt_decrypt($cipher, $key, $data, $mode, $iv = null)
     list($prefix) = explode('-', $cipher);
 
     switch ($prefix) {
-
         case 'tripledes':
             $crypt = new TripleDES();
             break;
+
+        default:
+            throw new \cweagans\mcrypt\Exception\NotImplementedException();
     }
 
     $crypt->setKey($key);


### PR DESCRIPTION
Here's a quick implementation of `MCRYPT_TRIPLEDES`.

Obviously, it's not perfect, but it passes:
tests/5.6/mcrypt_encrypt_3des_cbc.phpt
tests/5.6/mcrypt_decrypt_3des_cbc.phpt

I did learn something interesting. We need to choose a PHP version of the tests to support. The behavior changes between versions. Both in output and warnings. I would imaging we want to support the most recent version.
